### PR TITLE
Exponential backoff

### DIFF
--- a/lib/nodelix/version_manager.ex
+++ b/lib/nodelix/version_manager.ex
@@ -186,12 +186,12 @@ defmodule Nodelix.VersionManager do
     computed_checksum == checksum or raise "invalid checksum"
   end
 
-  def fetch_archive(version, _url, max_retries, tries, _fetch_fun) when tries >= max_retries do
+  defp fetch_archive(version, _url, max_retries, tries, _fetch_fun) when tries >= max_retries do
     Logger.debug("[Nodelix] Fetching node #{version}  failed after #{tries} attempts.")
     {:error, :max_retries_exceeded}
   end
 
-  def fetch_archive(version, archive_base_url, max_retries, tries, fetch_fun) do
+  defp fetch_archive(version, archive_base_url, max_retries, tries, fetch_fun) do
     archive_url = get_url(archive_base_url, version)
     %{archive: archive_path} = paths(version)
 

--- a/lib/nodelix/version_manager.ex
+++ b/lib/nodelix/version_manager.ex
@@ -55,15 +55,19 @@ defmodule Nodelix.VersionManager do
 
   @doc """
   Installs the specified Node.js version.
+  By default, it only attempts the download once, because the exponential backoff
+  makes the process sleep to preserve the current synchronous API.
+  Setting max_attempts to an integer greater than 1 will make the process sleep for
+  1500ms * attempt_n^2, so : 1.5s, 6s, 13.5s, 24s...
   """
-  @spec install(String.t(), String.t()) :: :ok
-  def install(version, archive_base_url \\ @default_archive_base_url)
+  @spec install(String.t(), String.t(), integer()) :: :ok
+  def install(version, archive_base_url \\ @default_archive_base_url, max_attempts \\ 1)
       when is_binary(version) and is_binary(archive_base_url) do
     %{nodelix: base_path} = paths(version)
 
     File.mkdir_p!(base_path)
 
-    fetch_archive(version, archive_base_url)
+    :ok = fetch_archive(version, archive_base_url, max_attempts)
     fetch_checksums(version)
     verify_archive!(version)
     unpack_archive(version)
@@ -184,13 +188,31 @@ defmodule Nodelix.VersionManager do
     computed_checksum == checksum or raise "invalid checksum"
   end
 
-  defp fetch_archive(version, archive_base_url) do
+  defp fetch_archive(_version, _url, max_retries, tries) when tries > max_retries do
+    {:error, :max_retries_exceeded}
+  end
+
+  defp fetch_archive(version, archive_base_url, max_retries, tries) do
     archive_url = get_url(archive_base_url, version)
     %{archive: archive_path} = paths(version)
 
     Logger.debug("Downloading Node.js from #{archive_url}")
-    binary = HttpUtils.fetch_body!(archive_url)
-    File.write!(archive_path, binary, [:binary])
+
+    try do
+      binary = HttpUtils.fetch_body!(archive_url)
+      File.write!(archive_path, binary, [:binary])
+      :ok
+    rescue
+      _ ->
+        case max_retries do
+          1 -> :error
+          _ -> Process.sleep(1_500 * :math.pow(2, tries))
+        end
+    end
+  end
+
+  defp fetch_archive(version, archive_base_url, max_retries) do
+    fetch_archive(version, archive_base_url, max_retries, 1)
   end
 
   defp fetch_checksums(version) do

--- a/lib/nodelix/version_manager.ex
+++ b/lib/nodelix/version_manager.ex
@@ -55,19 +55,17 @@ defmodule Nodelix.VersionManager do
 
   @doc """
   Installs the specified Node.js version.
-  By default, it only attempts the download once, because the exponential backoff
-  makes the process sleep to preserve the current synchronous API.
   Setting max_attempts to an integer greater than 1 will make the process sleep for
   1500ms * attempt_n^2, so : 1.5s, 6s, 13.5s, 24s...
   """
   @spec install(String.t(), String.t(), integer()) :: :ok
-  def install(version, archive_base_url \\ @default_archive_base_url, max_attempts \\ 1)
+  def install(version, archive_base_url \\ @default_archive_base_url, max_attempts \\ 3)
       when is_binary(version) and is_binary(archive_base_url) do
     %{nodelix: base_path} = paths(version)
 
     File.mkdir_p!(base_path)
 
-    :ok = fetch_archive(version, archive_base_url, max_attempts)
+    :ok = fetch_archive(version, archive_base_url, max_attempts, &HttpUtils.fetch_body!/1)
     fetch_checksums(version)
     verify_archive!(version)
     unpack_archive(version)
@@ -188,31 +186,36 @@ defmodule Nodelix.VersionManager do
     computed_checksum == checksum or raise "invalid checksum"
   end
 
-  defp fetch_archive(_version, _url, max_retries, tries) when tries > max_retries do
+  def fetch_archive(version, _url, max_retries, tries, _fetch_fun) when tries >= max_retries do
+    Logger.debug("[Nodelix] Fetching node #{version}  failed after #{tries} attempts.")
     {:error, :max_retries_exceeded}
   end
 
-  defp fetch_archive(version, archive_base_url, max_retries, tries) do
+  def fetch_archive(version, archive_base_url, max_retries, tries, fetch_fun) do
     archive_url = get_url(archive_base_url, version)
     %{archive: archive_path} = paths(version)
 
-    Logger.debug("Downloading Node.js from #{archive_url}")
+    Logger.debug("[Nodelix] Downloading Node.js from #{archive_url}")
 
     try do
-      binary = HttpUtils.fetch_body!(archive_url)
+      binary = fetch_fun.(archive_url)
       File.write!(archive_path, binary, [:binary])
       :ok
     rescue
       _ ->
-        case max_retries do
-          1 -> :error
-          _ -> Process.sleep(1_500 * :math.pow(2, tries))
-        end
+        sleep_time = trunc(1_500 * :math.pow(2, tries))
+
+        Logger.debug(
+          "[Nodelix] Fetching node #{version}  failed after #{tries} attempts. New attempt in #{sleep_time}ms"
+        )
+
+        Process.sleep(sleep_time)
+        fetch_archive(version, archive_base_url, max_retries, tries + 1, fetch_fun)
     end
   end
 
-  defp fetch_archive(version, archive_base_url, max_retries) do
-    fetch_archive(version, archive_base_url, max_retries, 1)
+  def fetch_archive(version, archive_base_url, max_retries, fetch_fun) do
+    fetch_archive(version, archive_base_url, max_retries, 0, fetch_fun)
   end
 
   defp fetch_checksums(version) do

--- a/test/nodelix/version_manager_test.exs
+++ b/test/nodelix/version_manager_test.exs
@@ -1,0 +1,60 @@
+defmodule Nodelix.VersionManagerTest do
+  use ExUnit.Case, async: true
+
+  setup do
+    :ets.new(:test_state, [:set, :public, :named_table])
+    :ok
+  end
+
+  @version "14.0.0"
+  @archive_base_url "https://nodejs.org/dist"
+
+  test "fetch_archive handles max retries exceeded" do
+    fetch_impl = fn _url ->
+      raise "Simulated failure"
+    end
+
+    assert {:error, :max_retries_exceeded} =
+             Nodelix.VersionManager.fetch_archive(
+               @version,
+               @archive_base_url,
+               2,
+               fetch_impl
+             )
+  end
+
+  test "fetch_archive succeeds after a few retries" do
+    :ets.insert(:test_state, {:fails_remaining, 2})
+
+    fetch_impl = fn _url ->
+      [{:fails_remaining, fails}] = :ets.lookup(:test_state, :fails_remaining)
+
+      if fails > 0 do
+        :ets.insert(:test_state, {:fails_remaining, fails - 1})
+        raise "Simulated failure"
+      else
+        "Simulated success"
+      end
+    end
+
+    assert :ok =
+             Nodelix.VersionManager.fetch_archive(
+               @version,
+               @archive_base_url,
+               3,
+               fetch_impl
+             )
+  end
+
+  test "fetch_archive succeeds immediately" do
+    fetch_impl = fn _url -> "simulated success" end
+
+    assert :ok =
+             Nodelix.VersionManager.fetch_archive(
+               @version,
+               @archive_base_url,
+               3,
+               fetch_impl
+             )
+  end
+end


### PR DESCRIPTION
Note that it should be made very clear that the current synchronous install will sleep if the user decides to handle Node.js server errors by setting max_attempts > 1.

I would personnally embed the install in an Oban job to make it part of a workflow DAG but I think it's cool to provide a vanilla backoff mechanism too. In the default case (max_attempts = 1), there's no sleeping involved.