### PR TITLE
First sigil/standalone scripts POC

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,4 +3,7 @@ import Config
 config :nodelix,
   test_profile: [
     args: ["--version"]
+  ],
+  standalone: [
+    args: []
   ]

--- a/lib/nodelix.ex
+++ b/lib/nodelix.ex
@@ -85,18 +85,15 @@ defmodule Nodelix do
       """
   end
 
-  @doc """
-  Runs the given command with `args`.
-
-  The given args will be appended to the configured args.
-  The task output will be streamed directly to stdio. It
-  returns the status of the underlying call.
-  """
-  def run(version, profile, extra_args \\ []) when is_atom(profile) and is_list(extra_args) do
-    config = config_for!(profile)
+  def build_args!(config, extra_args) do
     args = (config[:args] || []) ++ extra_args
-
     if length(args) == 0, do: raise(ArgumentError, "No argument provided.")
+    args
+  end
+
+  def build_args_and_opts(profile, extra_args) do
+    config = config_for!(profile)
+    args = build_args!(config, extra_args)
 
     env = Keyword.get(config, :env, %{})
 
@@ -107,16 +104,38 @@ defmodule Nodelix do
       stderr_to_stdout: true
     ]
 
+    {args, opts}
+  end
+
+  @doc """
+  Runs the given command with `args`.
+
+  The given args will be appended to the configured args.
+  The task output will be streamed directly to stdio. It
+  returns the status of the underlying call.
+  """
+  def run(version, profile, extra_args \\ []) when is_atom(profile) and is_list(extra_args) do
+    {args, opts} =
+      build_args_and_opts(profile, extra_args)
+
     VersionManager.bin_path(:node, version)
     |> System.cmd(args, opts)
     |> elem(1)
   end
 
-  @doc """
-  Same as `run/3` but using the latest known LTS version at the time of publishing.
-  """
-  def run_lts(profile, extra_args \\ []) when is_atom(profile) and is_list(extra_args) do
-    run(VersionManager.latest_lts_version(), profile, extra_args)
+  def run_standalone(version, script, options \\ []) do
+    {args, opts} =
+      build_args_and_opts(:standalone, [script])
+
+    {_, res} =
+      VersionManager.bin_path(:node, version)
+      |> System.cmd(args, opts)
+
+    if Keyword.get(options, :erase) do
+      File.rm!(script)
+    end
+
+    res
   end
 
   @doc """
@@ -131,13 +150,5 @@ defmodule Nodelix do
     end
 
     run(version, profile, args)
-  end
-
-  @doc """
-  Same as `install_and_run/3` but using the latest known LTS version at the time of publishing.
-  """
-  def install_and_run_lts(profile, extra_args \\ [])
-      when is_atom(profile) and is_list(extra_args) do
-    install_and_run(VersionManager.latest_lts_version(), profile, extra_args)
   end
 end

--- a/lib/nodelix/samples/block_usage.ex
+++ b/lib/nodelix/samples/block_usage.ex
@@ -1,0 +1,23 @@
+defmodule Nodelix.Samples.BlockUsage do
+  import Nodelix.SigilNode
+  alias Nodelix.VersionManager
+
+  def hello_from_node_script(target) do
+    node_script do
+      """
+      console.log("Hello #{target} !")
+      """
+    end
+  end
+
+  def run_sample() do
+    vsn = VersionManager.latest_lts_version()
+
+    if !VersionManager.is_installed?(vsn) do
+      VersionManager.install(vsn)
+    end
+
+    script = hello_from_node_script("world")
+    Nodelix.run_standalone(vsn, script, erase: true)
+  end
+end

--- a/lib/nodelix/samples/sigil_usage.ex
+++ b/lib/nodelix/samples/sigil_usage.ex
@@ -1,0 +1,24 @@
+defmodule Nodelix.Samples.SigilUsage do
+  import Nodelix.SigilNode
+  alias Nodelix.VersionManager
+
+  def hello_from_node_script() do
+    sigil_NODE(
+      """
+      console.log("Hello world !")
+      """,
+      []
+    )
+  end
+
+  def run_sample() do
+    vsn = VersionManager.latest_lts_version()
+
+    if !VersionManager.is_installed?(vsn) do
+      VersionManager.install(vsn)
+    end
+
+    script = hello_from_node_script()
+    Nodelix.run_standalone(vsn, script, erase: true)
+  end
+end

--- a/lib/nodelix/sigil_node.ex
+++ b/lib/nodelix/sigil_node.ex
@@ -1,0 +1,30 @@
+defmodule Nodelix.SigilNode do
+  defp tmp_filename() do
+    suffix = :crypto.strong_rand_bytes(32) |> Base.encode16() |> String.slice(0..31)
+    "nodelix_" <> suffix <> ".js"
+  end
+
+  defp get_tmp_path() do
+    Path.join(System.tmp_dir!(), tmp_filename())
+  end
+
+  @doc """
+  Convenience macro to circumvent the lack of interpolation in multiline sigils.
+  """
+  defmacro node_script(do_block) do
+    {:sigil_NODE, [delimiter: "\"\"\"", context: Elixir.Nodelix.SigilNode, imports: []],
+     [
+       {:<<>>, [indentation: 0],
+        [
+          Keyword.get(do_block, :do)
+        ]},
+       []
+     ]}
+  end
+
+  def sigil_NODE(body, _opts) do
+    filename = get_tmp_path()
+    File.write!(filename, body)
+    filename
+  end
+end

--- a/lib/nodelix/sigil_node/formatter.ex
+++ b/lib/nodelix/sigil_node/formatter.ex
@@ -1,0 +1,30 @@
+defmodule Nodelix.SigilNode.Formatter do
+  @behaviour Mix.Tasks.Format
+
+  def features(_opts) do
+    [sigils: [:NODE], extensions: []]
+  end
+
+  def format(contents, opts) do
+    parser =
+      case opts[:sigil] do
+        :NODE -> "acorn"
+      end
+
+    c = """
+    <<'EOF'
+    #{contents}
+    EOF
+    """
+
+    command = "prettier --parser #{parser} #{c}"
+    port = Port.open({:spawn, command}, [:binary])
+
+    receive do
+      {^port, {:data, d}} -> d
+      _ -> contents
+    end
+  rescue
+    _ -> contents
+  end
+end


### PR DESCRIPTION
WIP on Sigils.
Currently not able to use the multi-letter sigil syntax in the repo since `.tool-versions` wants elixir 1.12. I'm only showing it as a call to `sigil_NODE/2`.

```elixir
~NODE"""
...
"""
```

### Nice-to-haves
- [ ] interpolation syntax in the sigil
- [ ] function call strategy : define an inline script in a way it becomes an anonymous function with arity N, arguments being passed as stdin ?
- [ ] user-configurable formatting (I'm showing my sample with Prettier here but it must be pluggable)

